### PR TITLE
Fix oil details in wood heating pdf

### DIFF
--- a/src/lib/pdf/SavingsReportPDF.tsx
+++ b/src/lib/pdf/SavingsReportPDF.tsx
@@ -284,12 +284,11 @@ export const SavingsReportPDF: React.FC<{ data: PDFData }> = ({ data }) => (
                   </>
                 )}
 
-                {/* Oil (default) */}
-                {!String(
-                  (data.lammitysmuoto || data.current_heating || '')
-                )
-                  .toLowerCase()
-                  .includes('kaasu') && (
+                {/* Oil */}
+                {/(öljy|oljy)/.test(
+                  String((data.lammitysmuoto || data.current_heating || ''))
+                    .toLowerCase()
+                ) && (
                   <>
                     <View style={styles.detailRow}>
                       <Text style={styles.detailLabel}>Öljyn kulutus:</Text>


### PR DESCRIPTION
Update PDF generation to only show oil-related fields when the heating type is explicitly oil, fixing an issue where wood heating displayed oil details.

---
<a href="https://cursor.com/background-agent?bcId=bc-24da7100-21fd-40d6-aaba-84f0349c00f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24da7100-21fd-40d6-aaba-84f0349c00f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

