### PR TITLE
Fix heating system red box value display

### DIFF
--- a/src/lib/pdf/SavingsReportPDF.tsx
+++ b/src/lib/pdf/SavingsReportPDF.tsx
@@ -148,7 +148,7 @@ export const SavingsReportPDF: React.FC<{ data: PDFData }> = ({ data }) => (
                 <View style={styles.costRow}>
                   <Text style={styles.costLabel}>1 vuosi</Text>
                   <Text style={[styles.costValue, styles.negative]}>
-                    {(data.menekin_hinta_vuosi || data.menekinhintavuosi || data.currentYear1Cost || data.current_yearly_cost || data.vesikiertoinen || '2600')}{' '}€
+                    {(data.menekin_hinta_vuosi || data.menekinhintavuosi || data.currentYear1Cost || data.current_yearly_cost || '0')}{' '}€
                   </Text>
                 </View>
                 <View style={[styles.costRow, styles.costRowHighlight]}>
@@ -241,7 +241,7 @@ export const SavingsReportPDF: React.FC<{ data: PDFData }> = ({ data }) => (
 
                 {/* Wood heating */}
                 {String(
-                  (data.lammitysmuoto || data.current_heating || '')
+                  (data.lammitysmuoto || data.current_heating || data.currentSystem || '')
                 )
                   .toLowerCase()
                   .includes('puu') && (
@@ -257,18 +257,18 @@ export const SavingsReportPDF: React.FC<{ data: PDFData }> = ({ data }) => (
                       <Text style={styles.detailLabel}>Puun hinta:</Text>
                       <Text style={styles.detailValue}>
                         {(() => {
-                          const val = Number(
+                          const price = Number(
                             String(
-                              data.menekin_hinta_vuosi || data.menekinhintavuosi || 0
+                              data.wood_price || data.woodPrice || '75'
                             )
                               .replace(/\s/g, '')
                               .replace(',', '.')
                           );
-                          return isNaN(val)
-                            ? (data.menekin_hinta_vuosi || data.menekinhintavuosi || '0')
-                            : val.toLocaleString('fi-FI');
+                          return isNaN(price)
+                            ? (data.wood_price || data.woodPrice || '75')
+                            : price.toLocaleString('fi-FI');
                         })()}{' '}
-                        €
+                        €/motti
                       </Text>
                     </View>
                     <View style={styles.detailRow}>
@@ -284,12 +284,12 @@ export const SavingsReportPDF: React.FC<{ data: PDFData }> = ({ data }) => (
                   </>
                 )}
 
-                {/* Oil (default) */}
-                {!String(
-                  (data.lammitysmuoto || data.current_heating || '')
+                {/* Oil */}
+                {String(
+                  (data.lammitysmuoto || data.current_heating || data.currentSystem || '')
                 )
                   .toLowerCase()
-                  .includes('kaasu') && (
+                  .includes('öljy') && (
                   <>
                     <View style={styles.detailRow}>
                       <Text style={styles.detailLabel}>Öljyn kulutus:</Text>


### PR DESCRIPTION
Corrected the display of values in the "Current heating system" red box in the PDF report.

The yearly cost was incorrectly falling back to a string value, the wood heating price was miscalculated, and oil details were displayed for non-oil heating types.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7fc2dcb-c23f-47a3-820e-09369ed72464">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7fc2dcb-c23f-47a3-820e-09369ed72464">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

