### PR TITLE
Nextjs build failure due to email service type error

### DIFF
--- a/src/lib/email-templates/utils.ts
+++ b/src/lib/email-templates/utils.ts
@@ -77,7 +77,8 @@ export function calculateLeadScore(lead: Lead): 'high' | 'medium' | 'low' {
 export const emailSubjects = {
   customer: () => `Säästölaskurin tulokset - Energiaykkönen`,
 
-  sales: () => `Uusi liidi laskurista`,
+  sales: (lead?: Lead) =>
+    `Uusi liidi laskurista${lead?.nimi ? ` - ${lead.nimi}` : ''}`,
 };
 
 /**


### PR DESCRIPTION
Update `emailSubjects.sales` to accept an optional `Lead` argument and include the lead's name in the subject.

This fixes a TypeScript build error where `emailSubjects.sales` was called with a `Lead` object but defined to take no arguments.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d996d4a-44f8-4ded-be12-681afd5e8847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d996d4a-44f8-4ded-be12-681afd5e8847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

